### PR TITLE
[feature] Add eager loading and relationship resolvers

### DIFF
--- a/golang/example/graph/comment.go
+++ b/golang/example/graph/comment.go
@@ -71,6 +71,17 @@ func (o Comment) UpdatedAt() *graphql.Time {
 	return nil // null.Time
 }
 
+// Post pointed to by the foreign key
+func (o Comment) Post() *Post {
+	if o.model.R == nil || o.model.R.Post == nil {
+		return nil
+	}
+	return &Post{
+		model: *o.model.R.Post,
+		db:    o.db,
+	}
+}
+
 // createCommentInput is an object to back Comment mutation (create) input type
 type createCommentInput struct {
 	PostID int32   `json:"post_id"`
@@ -148,7 +159,12 @@ func (r *Resolver) AllComments(ctx context.Context, args struct {
 	Search   *searchCommentArgs
 }) (CommentsCollection, error) {
 	result := CommentsCollection{}
-	mods := []qm.QueryMod{qm.Limit(int(args.PageSize))}
+	mods := []qm.QueryMod{
+		qm.Limit(int(args.PageSize)),
+		// TODO: Add eager loading based on requested fields
+		qm.Load("Post"),
+	}
+
 	if args.Since != nil {
 		s := string(*args.Since)
 		i, err := strconv.ParseInt(s, 10, 64)

--- a/golang/example/graph/schema.go
+++ b/golang/example/graph/schema.go
@@ -84,6 +84,7 @@ type Comment {
 		notes: String
 		createdAt: Time
 		updatedAt: Time
+		post: Post
 }
 
 type CommentsCollection {
@@ -125,6 +126,7 @@ type Post {
 		notes: String
 		createdAt: Time
 		updatedAt: Time
+		comments: CommentsCollection
 }
 
 type PostsCollection {

--- a/golang/sqlboiler/templates/01_create_input.tpl
+++ b/golang/sqlboiler/templates/01_create_input.tpl
@@ -1,7 +1,7 @@
 {{- $tableNameSingular := .Table.Name | singular -}}
 {{- $modelName := $tableNameSingular | titleCase -}}
 {{- $modelNameCamel := $tableNameSingular | camelCase -}}
-{{- $pkColNames := .Table.PKey.Columns }}
+{{- $pkColNames := .Table.PKey.Columns -}}
 
 // create{{$modelName}}Input is an object to back {{$modelName}} mutation (create) input type
 type create{{$modelName}}Input struct {

--- a/golang/sqlboiler/templates/02_update_input.tpl
+++ b/golang/sqlboiler/templates/02_update_input.tpl
@@ -1,7 +1,7 @@
 {{- $tableNameSingular := .Table.Name | singular -}}
 {{- $modelName := $tableNameSingular | titleCase -}}
 {{- $modelNameCamel := $tableNameSingular | camelCase -}}
-{{- $pkColNames := .Table.PKey.Columns }}
+{{- $pkColNames := .Table.PKey.Columns -}}
 
 // update{{$modelName}}Input is an object to back {{$modelName}} mutation (update) input type
 type update{{$modelName}}Input struct {

--- a/golang/sqlboiler/templates/03_search_args.tpl
+++ b/golang/sqlboiler/templates/03_search_args.tpl
@@ -1,7 +1,7 @@
 {{- $tableNameSingular := .Table.Name | singular -}}
 {{- $modelName := $tableNameSingular | titleCase -}}
 {{- $modelNameCamel := $tableNameSingular | camelCase -}}
-{{- $pkColNames := .Table.PKey.Columns }}
+{{- $pkColNames := .Table.PKey.Columns -}}
 
 // search{{$modelName}}Args is an object to back {{$modelName}} search arguments type
 type search{{$modelName}}Args struct {

--- a/golang/sqlboiler/templates/singleton/schema.tpl
+++ b/golang/sqlboiler/templates/singleton/schema.tpl
@@ -12,13 +12,14 @@ type Query {
 {{range $table := .Tables}}
 {{- $tableNameSingular := .Name | singular -}}
 {{- $modelName := $tableNameSingular | titleCase -}}
+{{- $modelNamePlural := $table.Name | plural | titleCase -}}
 {{- $modelNameCamel := $tableNameSingular | camelCase}}
 
-  all{{$modelName}}s(
+  all{{$modelNamePlural}}(
     since: ID
     pageSize: Int!
     search: Search{{$modelName}}Args
-  ): {{$modelName}}sCollection!
+  ): {{$modelNamePlural}}Collection!
 
   {{$modelNameCamel}}ByID(
     id: ID!
@@ -30,6 +31,7 @@ type Mutation {
 {{range $table := .Tables}}
 {{- $tableNameSingular := .Name | singular -}}
 {{- $modelName := $tableNameSingular | titleCase -}}
+{{- $modelNamePlural := $table.Name | plural | titleCase -}}
 {{- $modelNameCamel := $tableNameSingular | camelCase}}
 
   create{{$modelName}}(
@@ -50,8 +52,10 @@ type Mutation {
 {{range $table := .Tables}}
 {{- $tableNameSingular := .Name | singular -}}
 {{- $modelName := $tableNameSingular | titleCase -}}
+{{- $modelNamePlural := $table.Name | plural | titleCase -}}
 {{- $modelNameCamel := $tableNameSingular | camelCase -}}
 {{- $pkColNames := $table.PKey.Columns -}}
+{{- $fkColDefs := $table.FKeys -}}
 
 type {{$modelName}} {
 	{{range $column := $table.Columns }}
@@ -103,9 +107,21 @@ type {{$modelName}} {
 		{{camelCase $column.Name}}: String!
 	{{- end -}}
 	{{- end }}
+	{{- /* Add to FK relationships */}}
+	{{- range $r := $fkColDefs }}
+		{{ $r.ForeignTable | singular | camelCase }}: {{ $r.ForeignTable | singular | titleCase }}
+	{{- end }}
+	{{- /* Add to one relationships */}}
+	{{- range $r := $table.ToOneRelationships }}
+		{{ $r.ForeignTable | singular | camelCase }}: {{ $r.ForeignTable | singular | titleCase }}
+	{{- end }}
+	{{- /* Add to many relationships */}}
+	{{- range $r := $table.ToManyRelationships }}
+		{{$r.ForeignTable | plural | camelCase }}: {{ $r.ForeignTable | plural | titleCase }}Collection
+	{{- end }}
 }
 
-type {{$modelName}}sCollection {
+type {{$modelNamePlural}}Collection {
 	nodes: [{{$modelName}}!]!
 }
 


### PR DESCRIPTION
### Summary 
- Add eager loading to help avoid n+1/optimise query for simple joins. Currently, it's just _eager loading_ all relationships, but can be further improved once the PR in https://github.com/graph-gophers/graphql-go/ that makes requested fields available on resolvers are merged. Please see issues/17, pull/70, and pull/169 for reference.
- Added relationship resolvers (schema + implementation) 
- Refactored the way plural names are being derived to be consistent with the default boiler templates 
- Tested template on odd table names (i.e. aaaaaYyy_Xxxxxx_ZZZ, gHHHHHHHHeeeeeeTnnn). 

_Not related to GraphQL templates but discovered that `sqlboiler` (default ORM templates) has issues with table names that starts with an uppercase. Two variables will have conflict due to same name: 
https://github.com/choonkeat/hellocrud/blob/db4e09e16eafd6dd9e1cbe51bb0bb986714bdd08/golang/example/dbmodel/comment.go#L37
https://github.com/choonkeat/hellocrud/blob/db4e09e16eafd6dd9e1cbe51bb0bb986714bdd08/golang/example/dbmodel/comment.go#L64_

#### Note: Please see inline comments below for more information