### PR TITLE
[chore] Split schema into types, inputs, and resolvers 

### DIFF
--- a/golang/Makefile
+++ b/golang/Makefile
@@ -9,13 +9,13 @@ generate: dbmigrate
 	go run cmd/url2toml/main.go -url "$(DATABASE_URL)" > sqlboiler.toml
 	# 2. generate db orm
 	sqlboiler --output example/dbmodel --pkgname dbmodel --schema app $(DBTYPE)
-	# 2. generate graphql types and resolvers
+	# 3. generate graphql types and resolvers
 	sqlboiler --output example/graph   --pkgname graph   --schema app --basedir sqlboiler/graph $(DBTYPE)
-	# 3. clean up generated go code
+	# 4. clean up generated go code
 	goimports -w example/*.go example/graph/*.go example/dbmodel/*.go
-	# 4. generate react+apollo crud
+	# 5. generate react+apollo crud
 	sqlboiler --output ../js/src   --pkgname js   --schema app --basedir sqlboiler/js $(DBTYPE)
-	# 4a. clean up generated js code; sqlboiler only generates `.go`
+	# 5a. clean up generated js code; sqlboiler only generates `.go`
 	# rm -f ../js/src/*js
 	go run cmd/sqlboiler2js/main.go ../js/src
 

--- a/golang/example/graph/schema.go
+++ b/golang/example/graph/schema.go
@@ -3,10 +3,17 @@
 
 package graph
 
-import graphql "github.com/graph-gophers/graphql-go"
+import (
+	"strings"
+
+	graphql "github.com/graph-gophers/graphql-go"
+)
 
 // Schema is the GraphQL schema
-var Schema = `
+var Schema string
+
+// schemaRoot is the GraphQL root schema containing query and mutation resolvers
+var schemaRoot = `
 scalar Time
 scalar Int64
 
@@ -21,7 +28,7 @@ type Query {
   allComments(
     since: ID
     pageSize: Int!
-    search: SearchCommentArgs
+    search: SearchCommentInput
   ): CommentsCollection!
 
   commentByID(
@@ -32,7 +39,7 @@ type Query {
   allPosts(
     since: ID
     pageSize: Int!
-    search: SearchPostArgs
+    search: SearchPostInput
   ): PostsCollection!
 
   postByID(
@@ -72,92 +79,22 @@ type Mutation {
   ): Post!
 
 }
-
-type Comment {
-	
-		# Convenient GUID for react component @key attribute
-		rowId: String!
-		id: ID!
-		postID: Int!
-		author: String!
-		body: String!
-		notes: String
-		createdAt: Time
-		updatedAt: Time
-		post: Post
-}
-
-type CommentsCollection {
-	nodes: [Comment!]!
-}
-
-input CreateCommentInput {
-	
-	  postID: Int!
-	  author: String!
-	  body: String!
-	  notes: String
-}
-
-input UpdateCommentInput {
-	
-	  postID: Int!
-	  author: String!
-	  body: String!
-	  notes: String
-}
-
-input SearchCommentArgs {
-	
-	  postID: Int
-	  author: String
-	  body: String
-	  notes: String
-}
-
-type Post {
-	
-		# Convenient GUID for react component @key attribute
-		rowId: String!
-		id: ID!
-		title: String!
-		author: String!
-		body: String!
-		notes: String
-		createdAt: Time
-		updatedAt: Time
-		comments: CommentsCollection
-}
-
-type PostsCollection {
-	nodes: [Post!]!
-}
-
-input CreatePostInput {
-	
-	  title: String!
-	  author: String!
-	  body: String!
-	  notes: String
-}
-
-input UpdatePostInput {
-	
-	  title: String!
-	  author: String!
-	  body: String!
-	  notes: String
-}
-
-input SearchPostArgs {
-	
-	  title: String
-	  author: String
-	  body: String
-	  notes: String
-}
-
-
 `
 
-var _ = graphql.MustParseSchema(Schema, &Resolver{})
+func init() {
+	strs := []string{
+		schemaRoot,
+		SchemaTypeComment,
+		SchemaCreateCommentInput,
+		SchemaUpdateCommentInput,
+		SchemaSearchCommentInput,
+		SchemaTypePost,
+		SchemaCreatePostInput,
+		SchemaUpdatePostInput,
+		SchemaSearchPostInput,
+	}
+	Schema = strings.Join(strs, "\n")
+
+	// Sanity check generated schema
+	graphql.MustParseSchema(Schema, &Resolver{})
+}

--- a/golang/sqlboiler/graph/templates/00_struct.tpl
+++ b/golang/sqlboiler/graph/templates/00_struct.tpl
@@ -1,8 +1,85 @@
 {{- $dot := . -}}
 {{- $tableNameSingular := .Table.Name | singular -}}
 {{- $modelName := $tableNameSingular | titleCase -}}
+{{- $modelNamePlural := .Table.Name | plural | titleCase -}}
 {{- $modelNameCamel := $tableNameSingular | camelCase -}}
 {{- $pkColNames := .Table.PKey.Columns -}}
+{{- $fkColDefs := .Table.FKeys -}}
+
+// SchemaType{{$modelName}} is the GraphQL schema type for {{$modelName}}
+var SchemaType{{$modelName}} = `
+# {{$modelName}} is a resource type
+type {{$modelName}} {
+	{{range $column := .Table.Columns }}
+	{{- if containsAny $pkColNames $column.Name }}
+		# Convenient GUID for ReactJS component @key attribute
+		rowId: String!
+		{{camelCase $column.Name}}: ID!
+	{{- else if eq $column.Type "[]byte" }}
+		{{camelCase $column.Name}}: String!
+	{{- else if eq $column.Type "bool" }}
+		{{camelCase $column.Name}}: Boolean!
+	{{- else if eq $column.Type "float32" }}
+		{{camelCase $column.Name}}: Float!
+	{{- else if eq $column.Type "float64" }}
+		{{camelCase $column.Name}}: Float!
+	{{- else if eq $column.Type "int" }}
+		{{camelCase $column.Name}}: Int!
+	{{- else if eq $column.Type "int16" }}
+		{{camelCase $column.Name}}: Int!
+	{{- else if eq $column.Type "int64" }}
+		{{camelCase $column.Name}}: Int64!
+	{{- else if eq $column.Type "null.Bool" }}
+		{{camelCase $column.Name}}: Boolean
+	{{- else if eq $column.Type "null.Byte" }}
+		{{camelCase $column.Name}}: string
+	{{- else if eq $column.Type "null.Bytes" }}
+		{{camelCase $column.Name}}: string
+	{{- else if eq $column.Type "null.Float64" }}
+		{{camelCase $column.Name}}: Float
+	{{- else if eq $column.Type "null.Int" }}
+		{{camelCase $column.Name}}: Int
+	{{- else if eq $column.Type "null.Int16" }}
+		{{camelCase $column.Name}}: Int
+	{{- else if eq $column.Type "null.Int64" }}
+		{{camelCase $column.Name}}: Int64
+	{{- else if eq $column.Type "null.JSON" }}
+		{{camelCase $column.Name}}: String
+	{{- else if eq $column.Type "null.String" }}
+		{{camelCase $column.Name}}: String
+	{{- else if eq $column.Type "null.Time" }}
+		{{camelCase $column.Name}}: Time
+	{{- else if eq $column.Type "string" }}
+		{{camelCase $column.Name}}: String!
+	{{- else if eq $column.Type "time.Time" }}
+		{{camelCase $column.Name}}: Time!
+	{{- else if eq $column.Type "types.Byte" }}
+		{{camelCase $column.Name}}: String!
+	{{- else if eq $column.Type "types.JSON" }}
+		{{camelCase $column.Name}}: String!
+	{{- end -}}
+	{{- end }}
+	{{- /* Add to FK relationships */}}
+	{{- range $r := $fkColDefs }}
+		# {{ $r.ForeignTable | singular | camelCase }} has a foreign key pointing to {{$modelName}}
+		{{ $r.ForeignTable | singular | camelCase }}: {{ $r.ForeignTable | singular | titleCase }}
+	{{- end }}
+	{{- /* Add to one relationships */}}
+	{{- range $r := .Table.ToOneRelationships }}
+		# {{ $r.ForeignTable | singular | camelCase }} has a one-to-one relationship with {{$modelName}}
+		{{ $r.ForeignTable | singular | camelCase }}: {{ $r.ForeignTable | singular | titleCase }}
+	{{- end }}
+	{{- /* Add to many relationships */}}
+	{{- range $r := .Table.ToManyRelationships }}
+		# {{ $r.ForeignTable | plural | camelCase }} has a many-to-one relationship with {{$modelName}}
+		{{$r.ForeignTable | plural | camelCase }}: {{ $r.ForeignTable | plural | titleCase }}Collection
+	{{- end }}
+}
+
+type {{$modelNamePlural}}Collection {
+	nodes: [{{$modelName}}!]!
+}
+`
 
 // {{$modelName}} is an object to back GraphQL type
 type {{$modelName}} struct {
@@ -192,3 +269,14 @@ func (o {{$modelName}}) {{$toManyModelNamePlural}}() *{{$toManyModelNamePlural}}
   return result
 }
 {{end -}}
+
+// {{$modelNamePlural}}Collection is the struct representing a collection of GraphQL types
+type {{$modelNamePlural}}Collection struct {
+	nodes []{{$modelName}}
+	// future meta data goes here, e.g. count
+}
+
+// Nodes returns the list of GraphQL types
+func (c {{$modelNamePlural}}Collection) Nodes(ctx context.Context) []{{$modelName}} {
+	return c.nodes
+}

--- a/golang/sqlboiler/graph/templates/01_create_input.tpl
+++ b/golang/sqlboiler/graph/templates/01_create_input.tpl
@@ -3,6 +3,63 @@
 {{- $modelNameCamel := $tableNameSingular | camelCase -}}
 {{- $pkColNames := .Table.PKey.Columns -}}
 
+// SchemaCreate{{$modelName}}Input is the schema create input for {{$modelName}}
+var SchemaCreate{{$modelName}}Input = `
+# Create{{$modelName}}Input is a create input type for {{$modelName}} resource
+input Create{{$modelName}}Input {
+	{{range $column := .Table.Columns }}
+	{{- if containsAny $pkColNames $column.Name }}
+	{{- else if eq $column.Name "created_by" }}
+	{{- else if eq $column.Name "created_at" }}
+	{{- else if eq $column.Name "updated_by" }}
+	{{- else if eq $column.Name "updated_at" }}
+	{{- else if eq $column.Type "[]byte" }}
+	  {{camelCase $column.Name}}: String!
+	{{- else if eq $column.Type "bool" }}
+	  {{camelCase $column.Name}}: Boolean!
+	{{- else if eq $column.Type "float32" }}
+	  {{camelCase $column.Name}}: Float!
+	{{- else if eq $column.Type "float64" }}
+	  {{camelCase $column.Name}}: Float!
+	{{- else if eq $column.Type "int" }}
+	  {{camelCase $column.Name}}: Int!
+	{{- else if eq $column.Type "int16" }}
+	  {{camelCase $column.Name}}: Int!
+	{{- else if eq $column.Type "int64" }}
+	  {{camelCase $column.Name}}: Int64!
+	{{- else if eq $column.Type "null.Bool" }}
+	  {{camelCase $column.Name}}: Boolean
+	{{- else if eq $column.Type "null.Byte" }}
+	  {{camelCase $column.Name}}: string
+	{{- else if eq $column.Type "null.Bytes" }}
+	  {{camelCase $column.Name}}: string
+	{{- else if eq $column.Type "null.Float64" }}
+	  {{camelCase $column.Name}}: Float
+	{{- else if eq $column.Type "null.Int" }}
+	  {{camelCase $column.Name}}: Int
+	{{- else if eq $column.Type "null.Int16" }}
+	  {{camelCase $column.Name}}: Int
+	{{- else if eq $column.Type "null.Int64" }}
+	  {{camelCase $column.Name}}: Int64
+	{{- else if eq $column.Type "null.JSON" }}
+	  {{camelCase $column.Name}}: String
+	{{- else if eq $column.Type "null.String" }}
+	  {{camelCase $column.Name}}: String
+	{{- else if eq $column.Type "null.Time" }}
+	  {{camelCase $column.Name}}: Time
+	{{- else if eq $column.Type "string" }}
+	  {{camelCase $column.Name}}: String!
+	{{- else if eq $column.Type "time.Time" }}
+	  {{camelCase $column.Name}}: Time!
+	{{- else if eq $column.Type "types.Byte" }}
+	  {{camelCase $column.Name}}: String!
+	{{- else if eq $column.Type "types.JSON" }}
+	  {{camelCase $column.Name}}: String!
+	{{- end -}}
+	{{- end }}
+}
+`
+
 // create{{$modelName}}Input is an object to back {{$modelName}} mutation (create) input type
 type create{{$modelName}}Input struct {
 {{range $column := .Table.Columns }}

--- a/golang/sqlboiler/graph/templates/02_update_input.tpl
+++ b/golang/sqlboiler/graph/templates/02_update_input.tpl
@@ -3,6 +3,62 @@
 {{- $modelNameCamel := $tableNameSingular | camelCase -}}
 {{- $pkColNames := .Table.PKey.Columns -}}
 
+// SchemaUpdate{{$modelName}}Input is the schema update input for {{$modelName}}
+var SchemaUpdate{{$modelName}}Input = `
+input Update{{$modelName}}Input {
+	{{range $column := .Table.Columns }}
+	{{- if containsAny $pkColNames $column.Name }}
+	{{- else if eq $column.Name "created_by" }}
+	{{- else if eq $column.Name "created_at" }}
+	{{- else if eq $column.Name "updated_by" }}
+	{{- else if eq $column.Name "updated_at" }}
+	{{- else if eq $column.Type "[]byte" }}
+	  {{camelCase $column.Name}}: String!
+	{{- else if eq $column.Type "bool" }}
+	  {{camelCase $column.Name}}: Boolean!
+	{{- else if eq $column.Type "float32" }}
+	  {{camelCase $column.Name}}: Float!
+	{{- else if eq $column.Type "float64" }}
+	  {{camelCase $column.Name}}: Float!
+	{{- else if eq $column.Type "int" }}
+	  {{camelCase $column.Name}}: Int!
+	{{- else if eq $column.Type "int16" }}
+	  {{camelCase $column.Name}}: Int!
+	{{- else if eq $column.Type "int64" }}
+	  {{camelCase $column.Name}}: Int64!
+	{{- else if eq $column.Type "null.Bool" }}
+	  {{camelCase $column.Name}}: Boolean
+	{{- else if eq $column.Type "null.Byte" }}
+	  {{camelCase $column.Name}}: string
+	{{- else if eq $column.Type "null.Bytes" }}
+	  {{camelCase $column.Name}}: string
+	{{- else if eq $column.Type "null.Float64" }}
+	  {{camelCase $column.Name}}: Float
+	{{- else if eq $column.Type "null.Int" }}
+	  {{camelCase $column.Name}}: Int
+	{{- else if eq $column.Type "null.Int16" }}
+	  {{camelCase $column.Name}}: Int
+	{{- else if eq $column.Type "null.Int64" }}
+	  {{camelCase $column.Name}}: Int64
+	{{- else if eq $column.Type "null.JSON" }}
+	  {{camelCase $column.Name}}: String
+	{{- else if eq $column.Type "null.String" }}
+	  {{camelCase $column.Name}}: String
+	{{- else if eq $column.Type "null.Time" }}
+	  {{camelCase $column.Name}}: Time
+	{{- else if eq $column.Type "string" }}
+	  {{camelCase $column.Name}}: String!
+	{{- else if eq $column.Type "time.Time" }}
+	  {{camelCase $column.Name}}: Time!
+	{{- else if eq $column.Type "types.Byte" }}
+	  {{camelCase $column.Name}}: String!
+	{{- else if eq $column.Type "types.JSON" }}
+	  {{camelCase $column.Name}}: String!
+	{{- end -}}
+	{{- end }}
+}
+`
+
 // update{{$modelName}}Input is an object to back {{$modelName}} mutation (update) input type
 type update{{$modelName}}Input struct {
 {{range $column := .Table.Columns }}

--- a/golang/sqlboiler/graph/templates/03_search_input.tpl
+++ b/golang/sqlboiler/graph/templates/03_search_input.tpl
@@ -1,0 +1,144 @@
+{{- $tableNameSingular := .Table.Name | singular -}}
+{{- $modelName := $tableNameSingular | titleCase -}}
+{{- $modelNameCamel := $tableNameSingular | camelCase -}}
+{{- $pkColNames := .Table.PKey.Columns -}}
+
+// SchemaSearch{{$modelName}}Input is the schema search input for {{$modelName}}
+var SchemaSearch{{$modelName}}Input = `
+# Search{{$modelName}}Input is a search input/arguments type for {{$modelName}} resources
+input Search{{$modelName}}Input {
+	{{range $column := .Table.Columns }}
+	{{- if containsAny $pkColNames $column.Name }}
+	{{- else if eq $column.Name "created_by" }}
+	{{- else if eq $column.Name "created_at" }}
+	{{- else if eq $column.Name "updated_by" }}
+	{{- else if eq $column.Name "updated_at" }}
+	{{- else if eq $column.Type "[]byte" }}
+	  {{camelCase $column.Name}}: String
+	{{- else if eq $column.Type "bool" }}
+	  {{camelCase $column.Name}}: Boolean
+	{{- else if eq $column.Type "float32" }}
+	  {{camelCase $column.Name}}: Float
+	{{- else if eq $column.Type "float64" }}
+	  {{camelCase $column.Name}}: Float
+	{{- else if eq $column.Type "int" }}
+	  {{camelCase $column.Name}}: Int
+	{{- else if eq $column.Type "int16" }}
+	  {{camelCase $column.Name}}: Int
+	{{- else if eq $column.Type "int64" }}
+	  {{camelCase $column.Name}}: Int64
+	{{- else if eq $column.Type "null.Bool" }}
+	  {{camelCase $column.Name}}: Boolean
+	{{- else if eq $column.Type "null.Byte" }}
+	  {{camelCase $column.Name}}: string
+	{{- else if eq $column.Type "null.Bytes" }}
+	  {{camelCase $column.Name}}: string
+	{{- else if eq $column.Type "null.Float64" }}
+	  {{camelCase $column.Name}}: Float
+	{{- else if eq $column.Type "null.Int" }}
+	  {{camelCase $column.Name}}: Int
+	{{- else if eq $column.Type "null.Int16" }}
+	  {{camelCase $column.Name}}: Int
+	{{- else if eq $column.Type "null.Int64" }}
+	  {{camelCase $column.Name}}: Int64
+	{{- else if eq $column.Type "null.JSON" }}
+	  {{camelCase $column.Name}}: String
+	{{- else if eq $column.Type "null.String" }}
+	  {{camelCase $column.Name}}: String
+	{{- else if eq $column.Type "null.Time" }}
+	  {{camelCase $column.Name}}: Time
+	{{- else if eq $column.Type "string" }}
+	  {{camelCase $column.Name}}: String
+	{{- else if eq $column.Type "time.Time" }}
+	  {{camelCase $column.Name}}: Time
+	{{- else if eq $column.Type "types.Byte" }}
+	  {{camelCase $column.Name}}: String
+	{{- else if eq $column.Type "types.JSON" }}
+	  {{camelCase $column.Name}}: String
+	{{- end -}}
+	{{- end }}
+}
+`
+
+// search{{$modelName}}Input is an object to back {{$modelName}} search arguments input type
+type search{{$modelName}}Input struct {
+{{range $column := .Table.Columns }}
+{{- if containsAny $pkColNames $column.Name }}
+{{- else if eq $column.Type "[]byte" }}
+  {{titleCase $column.Name}} *[]byte `json:"{{$column.Name }}"` 
+{{- else if eq $column.Type "bool" }}
+  {{titleCase $column.Name}} *bool `json:"{{$column.Name }}"` 
+{{- else if eq $column.Type "float32" }}
+  {{titleCase $column.Name}} *float64 `json:"{{$column.Name }}"` 
+{{- else if eq $column.Type "float64" }}
+  {{titleCase $column.Name}} *float64 `json:"{{$column.Name }}"` 
+{{- else if eq $column.Type "int" }}
+  {{titleCase $column.Name}} *int32 `json:"{{$column.Name }}"` 
+{{- else if eq $column.Type "int16" }}
+  {{titleCase $column.Name}} *int32 `json:"{{$column.Name }}"` 
+{{- else if eq $column.Type "int64" }}
+  {{titleCase $column.Name}} *Int64 `json:"{{$column.Name }}"` 
+{{- else if eq $column.Type "null.Bool" }}
+  {{titleCase $column.Name}} *bool `json:"{{$column.Name }}"` 
+{{- else if eq $column.Type "null.Byte" }}
+  {{titleCase $column.Name}} *byte `json:"{{$column.Name }}"` 
+{{- else if eq $column.Type "null.Bytes" }}
+  {{titleCase $column.Name}} *[]byte `json:"{{$column.Name }}"` 
+{{- else if eq $column.Type "null.Float64" }}
+  {{titleCase $column.Name}} *float64 `json:"{{$column.Name }}"` 
+{{- else if eq $column.Type "null.Int" }}
+  {{titleCase $column.Name}} *int32 `json:"{{$column.Name }}"` 
+{{- else if eq $column.Type "null.Int16" }}
+  {{titleCase $column.Name}} *int32 `json:"{{$column.Name }}"` 
+{{- else if eq $column.Type "null.Int64" }}
+  {{titleCase $column.Name}} *Int64 `json:"{{$column.Name }}"` 
+{{- else if eq $column.Type "null.JSON" }}
+  {{titleCase $column.Name}} *[]byte `json:"{{$column.Name }}"` 
+{{- else if eq $column.Type "null.String" }}
+  {{titleCase $column.Name}} *string `json:"{{$column.Name }}"` 
+{{- else if eq $column.Type "null.Time" }}
+  {{titleCase $column.Name}} *graphql.Time `json:"{{$column.Name }}"`
+{{- else if eq $column.Type "string" }}
+  {{titleCase $column.Name}} *string `json:"{{$column.Name }}"` 
+{{- else if eq $column.Type "time.Time" }}
+  {{titleCase $column.Name}} *graphql.Time `json:"{{$column.Name }}"`
+{{- else if eq $column.Type "types.Byte" }}
+  {{titleCase $column.Name}} *string `json:"{{$column.Name }}"` 
+{{- else if eq $column.Type "types.JSON" }}
+  {{titleCase $column.Name}} *string `json:"{{$column.Name }}"` 
+{{- end -}}
+{{- end }}
+}
+
+// QueryMods returns a list of QueryMod based on the struct values
+func (s *search{{$modelName}}Input) QueryMods() []qm.QueryMod {
+  mods := []qm.QueryMod{}
+  // Get reflect value
+  v := reflect.ValueOf(s).Elem()
+  // Iterate struct fields
+  for i := 0; i < v.NumField(); i++ {
+    field := v.Type().Field(i) // StructField
+    value := v.Field(i) // Value
+    if value.IsNil() || !value.IsValid() {
+      // Skip if field is nil
+      continue
+    }
+
+    // Get column name from tags
+    column, hasColumnName := field.Tag.Lookup("json")
+    // Skip if no DB definition
+    if !hasColumnName {
+      continue
+    }
+
+    operator := "="
+    val := value.Elem().Interface()
+    if dataType := field.Type.String(); (dataType == "string" || dataType == "*string") &&
+      val.(string) != "" {
+      operator = "LIKE"
+      val = fmt.Sprintf("%%%s%%", val)
+    }
+    mods = append(mods, qm.And(fmt.Sprintf("%s %s ?", column, operator), val))
+  }
+  return mods
+}

--- a/golang/sqlboiler/graph/templates/10_resolver.tpl
+++ b/golang/sqlboiler/graph/templates/10_resolver.tpl
@@ -5,22 +5,11 @@
 {{- $modelNameCamel := $tableNameSingular | camelCase}}
 {{- $pkColDefs := sqlColDefinitions .Table.Columns .Table.PKey.Columns}}
 
-// {{$modelNamePlural}}Collection is the struct representing a collection of GraphQL types
-type {{$modelNamePlural}}Collection struct {
-	nodes []{{$modelName}}
-	// future meta data goes here, e.g. count
-}
-
-// Nodes returns the list of GraphQL types
-func (c {{$modelNamePlural}}Collection) Nodes(ctx context.Context) []{{$modelName}} {
-	return c.nodes
-}
-
 // All{{$modelNamePlural}} retrieves {{$modelNamePlural}} based on the provided search parameters
 func (r *Resolver) All{{$modelNamePlural}}(ctx context.Context, args struct {
 	Since    *graphql.ID
 	PageSize int32
-	Search *search{{$modelName}}Args
+	Search *search{{$modelName}}Input
 }) ({{$modelNamePlural}}Collection, error) {
 	result := {{$modelNamePlural}}Collection{}
 	mods := []qm.QueryMod{

--- a/golang/sqlboiler/graph/templates/singleton/schema.tpl
+++ b/golang/sqlboiler/graph/templates/singleton/schema.tpl
@@ -34,7 +34,7 @@ type Mutation {
 {{range $table := .Tables}}
 {{- $tableNameSingular := .Name | singular -}}
 {{- $modelName := $tableNameSingular | titleCase -}}
-{{- $mosdelNamePlural := $table.Name | plural | titleCase -}}
+{{- $modelNamePlural := $table.Name | plural | titleCase -}}
 {{- $modelNameCamel := $tableNameSingular | camelCase}}
 
   create{{$modelName}}(

--- a/golang/sqlboiler/graph/templates/singleton/schema.tpl
+++ b/golang/sqlboiler/graph/templates/singleton/schema.tpl
@@ -1,5 +1,8 @@
 // Schema is the GraphQL schema
-var Schema = `
+var Schema string
+
+// schemaRoot is the GraphQL root schema containing query and mutation resolvers
+var schemaRoot = `
 scalar Time
 scalar Int64
 
@@ -18,7 +21,7 @@ type Query {
   all{{$modelNamePlural}}(
     since: ID
     pageSize: Int!
-    search: Search{{$modelName}}Args
+    search: Search{{$modelName}}Input
   ): {{$modelNamePlural}}Collection!
 
   {{$modelNameCamel}}ByID(
@@ -31,7 +34,7 @@ type Mutation {
 {{range $table := .Tables}}
 {{- $tableNameSingular := .Name | singular -}}
 {{- $modelName := $tableNameSingular | titleCase -}}
-{{- $modelNamePlural := $table.Name | plural | titleCase -}}
+{{- $mosdelNamePlural := $table.Name | plural | titleCase -}}
 {{- $modelNameCamel := $tableNameSingular | camelCase}}
 
   create{{$modelName}}(
@@ -48,243 +51,22 @@ type Mutation {
   ): {{$modelName}}!
 {{end}}
 }
-
-{{range $table := .Tables}}
-{{- $tableNameSingular := .Name | singular -}}
-{{- $modelName := $tableNameSingular | titleCase -}}
-{{- $modelNamePlural := $table.Name | plural | titleCase -}}
-{{- $modelNameCamel := $tableNameSingular | camelCase -}}
-{{- $pkColNames := $table.PKey.Columns -}}
-{{- $fkColDefs := $table.FKeys -}}
-
-type {{$modelName}} {
-	{{range $column := $table.Columns }}
-	{{- if containsAny $pkColNames $column.Name }}
-		# Convenient GUID for react component @key attribute
-		rowId: String!
-		{{camelCase $column.Name}}: ID!
-	{{- else if eq $column.Type "[]byte" }}
-		{{camelCase $column.Name}}: String!
-	{{- else if eq $column.Type "bool" }}
-		{{camelCase $column.Name}}: Boolean!
-	{{- else if eq $column.Type "float32" }}
-		{{camelCase $column.Name}}: Float!
-	{{- else if eq $column.Type "float64" }}
-		{{camelCase $column.Name}}: Float!
-	{{- else if eq $column.Type "int" }}
-		{{camelCase $column.Name}}: Int!
-	{{- else if eq $column.Type "int16" }}
-		{{camelCase $column.Name}}: Int!
-	{{- else if eq $column.Type "int64" }}
-		{{camelCase $column.Name}}: Int64!
-	{{- else if eq $column.Type "null.Bool" }}
-		{{camelCase $column.Name}}: Boolean
-	{{- else if eq $column.Type "null.Byte" }}
-		{{camelCase $column.Name}}: string
-	{{- else if eq $column.Type "null.Bytes" }}
-		{{camelCase $column.Name}}: string
-	{{- else if eq $column.Type "null.Float64" }}
-		{{camelCase $column.Name}}: Float
-	{{- else if eq $column.Type "null.Int" }}
-		{{camelCase $column.Name}}: Int
-	{{- else if eq $column.Type "null.Int16" }}
-		{{camelCase $column.Name}}: Int
-	{{- else if eq $column.Type "null.Int64" }}
-		{{camelCase $column.Name}}: Int64
-	{{- else if eq $column.Type "null.JSON" }}
-		{{camelCase $column.Name}}: String
-	{{- else if eq $column.Type "null.String" }}
-		{{camelCase $column.Name}}: String
-	{{- else if eq $column.Type "null.Time" }}
-		{{camelCase $column.Name}}: Time
-	{{- else if eq $column.Type "string" }}
-		{{camelCase $column.Name}}: String!
-	{{- else if eq $column.Type "time.Time" }}
-		{{camelCase $column.Name}}: Time!
-	{{- else if eq $column.Type "types.Byte" }}
-		{{camelCase $column.Name}}: String!
-	{{- else if eq $column.Type "types.JSON" }}
-		{{camelCase $column.Name}}: String!
-	{{- end -}}
-	{{- end }}
-	{{- /* Add to FK relationships */}}
-	{{- range $r := $fkColDefs }}
-		{{ $r.ForeignTable | singular | camelCase }}: {{ $r.ForeignTable | singular | titleCase }}
-	{{- end }}
-	{{- /* Add to one relationships */}}
-	{{- range $r := $table.ToOneRelationships }}
-		{{ $r.ForeignTable | singular | camelCase }}: {{ $r.ForeignTable | singular | titleCase }}
-	{{- end }}
-	{{- /* Add to many relationships */}}
-	{{- range $r := $table.ToManyRelationships }}
-		{{$r.ForeignTable | plural | camelCase }}: {{ $r.ForeignTable | plural | titleCase }}Collection
-	{{- end }}
-}
-
-type {{$modelNamePlural}}Collection {
-	nodes: [{{$modelName}}!]!
-}
-
-input Create{{$modelName}}Input {
-	{{range $column := $table.Columns }}
-	{{- if containsAny $pkColNames $column.Name }}
-	{{- else if eq $column.Name "created_by" }}
-	{{- else if eq $column.Name "created_at" }}
-	{{- else if eq $column.Name "updated_by" }}
-	{{- else if eq $column.Name "updated_at" }}
-	{{- else if eq $column.Type "[]byte" }}
-	  {{camelCase $column.Name}}: String!
-	{{- else if eq $column.Type "bool" }}
-	  {{camelCase $column.Name}}: Boolean!
-	{{- else if eq $column.Type "float32" }}
-	  {{camelCase $column.Name}}: Float!
-	{{- else if eq $column.Type "float64" }}
-	  {{camelCase $column.Name}}: Float!
-	{{- else if eq $column.Type "int" }}
-	  {{camelCase $column.Name}}: Int!
-	{{- else if eq $column.Type "int16" }}
-	  {{camelCase $column.Name}}: Int!
-	{{- else if eq $column.Type "int64" }}
-	  {{camelCase $column.Name}}: Int64!
-	{{- else if eq $column.Type "null.Bool" }}
-	  {{camelCase $column.Name}}: Boolean
-	{{- else if eq $column.Type "null.Byte" }}
-	  {{camelCase $column.Name}}: string
-	{{- else if eq $column.Type "null.Bytes" }}
-	  {{camelCase $column.Name}}: string
-	{{- else if eq $column.Type "null.Float64" }}
-	  {{camelCase $column.Name}}: Float
-	{{- else if eq $column.Type "null.Int" }}
-	  {{camelCase $column.Name}}: Int
-	{{- else if eq $column.Type "null.Int16" }}
-	  {{camelCase $column.Name}}: Int
-	{{- else if eq $column.Type "null.Int64" }}
-	  {{camelCase $column.Name}}: Int64
-	{{- else if eq $column.Type "null.JSON" }}
-	  {{camelCase $column.Name}}: String
-	{{- else if eq $column.Type "null.String" }}
-	  {{camelCase $column.Name}}: String
-	{{- else if eq $column.Type "null.Time" }}
-	  {{camelCase $column.Name}}: Time
-	{{- else if eq $column.Type "string" }}
-	  {{camelCase $column.Name}}: String!
-	{{- else if eq $column.Type "time.Time" }}
-	  {{camelCase $column.Name}}: Time!
-	{{- else if eq $column.Type "types.Byte" }}
-	  {{camelCase $column.Name}}: String!
-	{{- else if eq $column.Type "types.JSON" }}
-	  {{camelCase $column.Name}}: String!
-	{{- end -}}
-	{{- end }}
-}
-
-input Update{{$modelName}}Input {
-	{{range $column := $table.Columns }}
-	{{- if containsAny $pkColNames $column.Name }}
-	{{- else if eq $column.Name "created_by" }}
-	{{- else if eq $column.Name "created_at" }}
-	{{- else if eq $column.Name "updated_by" }}
-	{{- else if eq $column.Name "updated_at" }}
-	{{- else if eq $column.Type "[]byte" }}
-	  {{camelCase $column.Name}}: String!
-	{{- else if eq $column.Type "bool" }}
-	  {{camelCase $column.Name}}: Boolean!
-	{{- else if eq $column.Type "float32" }}
-	  {{camelCase $column.Name}}: Float!
-	{{- else if eq $column.Type "float64" }}
-	  {{camelCase $column.Name}}: Float!
-	{{- else if eq $column.Type "int" }}
-	  {{camelCase $column.Name}}: Int!
-	{{- else if eq $column.Type "int16" }}
-	  {{camelCase $column.Name}}: Int!
-	{{- else if eq $column.Type "int64" }}
-	  {{camelCase $column.Name}}: Int64!
-	{{- else if eq $column.Type "null.Bool" }}
-	  {{camelCase $column.Name}}: Boolean
-	{{- else if eq $column.Type "null.Byte" }}
-	  {{camelCase $column.Name}}: string
-	{{- else if eq $column.Type "null.Bytes" }}
-	  {{camelCase $column.Name}}: string
-	{{- else if eq $column.Type "null.Float64" }}
-	  {{camelCase $column.Name}}: Float
-	{{- else if eq $column.Type "null.Int" }}
-	  {{camelCase $column.Name}}: Int
-	{{- else if eq $column.Type "null.Int16" }}
-	  {{camelCase $column.Name}}: Int
-	{{- else if eq $column.Type "null.Int64" }}
-	  {{camelCase $column.Name}}: Int64
-	{{- else if eq $column.Type "null.JSON" }}
-	  {{camelCase $column.Name}}: String
-	{{- else if eq $column.Type "null.String" }}
-	  {{camelCase $column.Name}}: String
-	{{- else if eq $column.Type "null.Time" }}
-	  {{camelCase $column.Name}}: Time
-	{{- else if eq $column.Type "string" }}
-	  {{camelCase $column.Name}}: String!
-	{{- else if eq $column.Type "time.Time" }}
-	  {{camelCase $column.Name}}: Time!
-	{{- else if eq $column.Type "types.Byte" }}
-	  {{camelCase $column.Name}}: String!
-	{{- else if eq $column.Type "types.JSON" }}
-	  {{camelCase $column.Name}}: String!
-	{{- end -}}
-	{{- end }}
-}
-
-input Search{{$modelName}}Args {
-	{{range $column := $table.Columns }}
-	{{- if containsAny $pkColNames $column.Name }}
-	{{- else if eq $column.Name "created_by" }}
-	{{- else if eq $column.Name "created_at" }}
-	{{- else if eq $column.Name "updated_by" }}
-	{{- else if eq $column.Name "updated_at" }}
-	{{- else if eq $column.Type "[]byte" }}
-	  {{camelCase $column.Name}}: String
-	{{- else if eq $column.Type "bool" }}
-	  {{camelCase $column.Name}}: Boolean
-	{{- else if eq $column.Type "float32" }}
-	  {{camelCase $column.Name}}: Float
-	{{- else if eq $column.Type "float64" }}
-	  {{camelCase $column.Name}}: Float
-	{{- else if eq $column.Type "int" }}
-	  {{camelCase $column.Name}}: Int
-	{{- else if eq $column.Type "int16" }}
-	  {{camelCase $column.Name}}: Int
-	{{- else if eq $column.Type "int64" }}
-	  {{camelCase $column.Name}}: Int64
-	{{- else if eq $column.Type "null.Bool" }}
-	  {{camelCase $column.Name}}: Boolean
-	{{- else if eq $column.Type "null.Byte" }}
-	  {{camelCase $column.Name}}: string
-	{{- else if eq $column.Type "null.Bytes" }}
-	  {{camelCase $column.Name}}: string
-	{{- else if eq $column.Type "null.Float64" }}
-	  {{camelCase $column.Name}}: Float
-	{{- else if eq $column.Type "null.Int" }}
-	  {{camelCase $column.Name}}: Int
-	{{- else if eq $column.Type "null.Int16" }}
-	  {{camelCase $column.Name}}: Int
-	{{- else if eq $column.Type "null.Int64" }}
-	  {{camelCase $column.Name}}: Int64
-	{{- else if eq $column.Type "null.JSON" }}
-	  {{camelCase $column.Name}}: String
-	{{- else if eq $column.Type "null.String" }}
-	  {{camelCase $column.Name}}: String
-	{{- else if eq $column.Type "null.Time" }}
-	  {{camelCase $column.Name}}: Time
-	{{- else if eq $column.Type "string" }}
-	  {{camelCase $column.Name}}: String
-	{{- else if eq $column.Type "time.Time" }}
-	  {{camelCase $column.Name}}: Time
-	{{- else if eq $column.Type "types.Byte" }}
-	  {{camelCase $column.Name}}: String
-	{{- else if eq $column.Type "types.JSON" }}
-	  {{camelCase $column.Name}}: String
-	{{- end -}}
-	{{- end }}
-}
-
-{{end}}
 `
 
-var _ = graphql.MustParseSchema(Schema, &Resolver{})
+func init() {
+	strs := []string{
+		schemaRoot,
+		{{range $table := .Tables}}
+		{{- $tableNameSingular := .Name | singular -}}
+		{{- $modelName := $tableNameSingular | titleCase -}}
+		SchemaType{{$modelName}},
+		SchemaCreate{{$modelName}}Input,
+		SchemaUpdate{{$modelName}}Input,
+		SchemaSearch{{$modelName}}Input,
+		{{end}}
+	}
+	Schema = strings.Join(strs, "\n")
+	
+	// Sanity check generated schema
+	graphql.MustParseSchema(Schema, &Resolver{})
+}


### PR DESCRIPTION
- Split GraphQL schema definition into different exported variables (and stitched together to create "the schema")
- Renamed `SearchXxxArgs` to `SearchXxxInput` for consistency (using the term _input_) 
- Add factory methods on GraphQL type

### Why?
- Had a use-case where I want to create a separate custom handler so that I can apply common middlewares on specific GraphQL handlers 
- The types generated by SQLBoiler will be useful and can be used by the custom schema handlers (i.e. Creating new queries/mutations but return type is based on the domain) 
- Factory methods for reusability of generated GraphQL types in other packages