### PR TITLE
[fix] Optionally add operation types to GraphQL schema

### DIFF
--- a/golang/sqlboiler/graph/templates/singleton/schema.tpl
+++ b/golang/sqlboiler/graph/templates/singleton/schema.tpl
@@ -4,7 +4,7 @@ var Schema string
 func init() {
 	var query strings.Builder
 	var mutation strings.Builder
-	var subscriptions strings.Builder
+	var subscription strings.Builder
 	var schema strings.Builder
 
 	matches, err := filepath.Glob("example/graph/schema/*.graphql")
@@ -24,22 +24,36 @@ func init() {
 		} else if strings.HasPrefix(basename, "mutation-") { // add your own `mutation-*.graphql` files
 			mutation.Write(data)
 		} else if strings.HasPrefix(basename, "subscription-") { // add your own `subscription-*.graphql` files
-			subscriptions.Write(data)
+			subscription.Write(data)
 		} else {
 			schema.Write(data)
 		}
 	}
 
+	operationFields := []string{}
+	operationTypes := []string{}
+	// Query
+	if strings.TrimSpace(query.String()) != "" {
+		operationFields = append(operationFields, "query: Query")
+		operationTypes = append(operationTypes, `type Query {`+query.String()+`}`)
+	}
+	// Mutation
+	if strings.TrimSpace(mutation.String()) != "" {
+		operationFields = append(operationFields, "mutation: Mutation")
+		operationTypes = append(operationTypes, `type Mutation {`+mutation.String()+`}`)
+	}
+	// Subscription
+	if strings.TrimSpace(subscription.String()) != "" {
+		operationFields = append(operationFields, "subscription: Subscription")
+		operationTypes = append(operationTypes, `type Subscription {`+subscription.String()+`}`)
+	}
+
 	Schema = `
-    schema {
-      query: Query
-      mutation: Mutation
-      subscription: Subscription
-    }
-    type Query {` + query.String() + `}
-    type Mutation {` + mutation.String() + `}
-    type Subscription {` + subscriptions.String() + `}
-  ` + schema.String()
+		schema {` +
+		strings.Join(operationFields, "\n") + // Operation fields associated to the types (i.e. query: Query, mutation: Mutation)
+		`}` +
+		strings.Join(operationTypes, "\n") + "\n" + // Operation types (i.e. type Query {}, type Mutation {})
+		schema.String() // Other schema types
 
 	graphql.MustParseSchema(Schema, &Resolver{})
 }


### PR DESCRIPTION
Ref: `graphql/graphiql/issues/16`
Fixes: 
```
Error: Subscription fields must be an object with field names as keys or a function which returns such an object.
    at invariant (https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.10.2/graphiql.js:24179:11)
    at defineFieldMap (https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.10.2/graphiql.js:27207:27)
    at GraphQLObjectType.getFields (https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.10.2/graphiql.js:27164:44)
    at typeMapReducer (https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.10.2/graphiql.js:28869:25)
    at Array.reduce (<anonymous>)
    at new GraphQLSchema (https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.10.2/graphiql.js:28758:34)
    at buildClientSchema (https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.10.2/graphiql.js:30166:10)
    at https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.10.2/graphiql.js:2140:55
```